### PR TITLE
CQ-4308826 - Create the new WF nodes under /conf and not /var

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.adobe</groupId>
     <artifactId>wf-migrator</artifactId>
     <name>AEM Assets as a Cloud Service - Workflow Migration Tool</name>
-    <version>0.2.5</version>
+    <version>0.2.6</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.adobe</groupId>
     <artifactId>wf-migrator</artifactId>
     <name>AEM Assets as a Cloud Service - Workflow Migration Tool</name>
-    <version>0.2.6</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
+++ b/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
@@ -12,12 +12,15 @@
 
 package com.adobe.skyline.migration;
 
-import com.adobe.skyline.migration.model.workflow.Workflow;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.adobe.skyline.migration.model.workflow.WorkflowLauncher;
 import com.adobe.skyline.migration.model.workflow.WorkflowStep;
-
-import java.io.File;
-import java.util.*;
 
 public class MigrationConstants {
 
@@ -121,6 +124,7 @@ public class MigrationConstants {
     public static final String NO_LAUNCHER_MSG = "No workflow launchers were disabled.";
     public static final String NO_RUNNER_CFG_MSG = "No workflow runner configurations were created.";
     public static final String NO_MODEL_UPDATE_MSG = "No workflow models were modified.";
+    public static final String NO_PATHS_DELETED_MSG = "No paths were deleted.";
     public static final String NO_PROFILE_MSG = "No processing profiles were created.";
     public static final String NO_PROJECT_MSG = "No Maven projects were created.";
 

--- a/src/main/java/com/adobe/skyline/migration/dao/FilterFileDAO.java
+++ b/src/main/java/com/adobe/skyline/migration/dao/FilterFileDAO.java
@@ -12,17 +12,21 @@
 
 package com.adobe.skyline.migration.dao;
 
-import com.adobe.skyline.migration.MigrationConstants;
-import com.adobe.skyline.migration.exception.MigrationRuntimeException;
-import com.adobe.skyline.migration.util.XmlUtil;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import javax.xml.transform.TransformerException;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
-import javax.xml.transform.TransformerException;
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
+import com.adobe.skyline.migration.MigrationConstants;
+import com.adobe.skyline.migration.exception.MigrationRuntimeException;
+import com.adobe.skyline.migration.util.XmlUtil;
 
 /**
  * An object to abstract reading from and writing to filter files in Maven content package projects.
@@ -33,6 +37,17 @@ public class FilterFileDAO {
 
     public FilterFileDAO(String projectPath) {
         this.filterFile = new File(projectPath + MigrationConstants.PATH_TO_FILTER_XML);
+    }
+
+    public boolean hasPath(String path) {
+        try {
+            Document filterXml = XmlUtil.loadXml(filterFile);
+            Element workspaceFilterElement = filterXml.getDocumentElement();
+
+            return hasEntry(workspaceFilterElement, path);
+        } catch (Exception e) {
+            throw new MigrationRuntimeException(e);
+        }
     }
 
     public void addPath(String path) {
@@ -48,6 +63,38 @@ public class FilterFileDAO {
         }
     }
 
+    public List<String> findPathsWith(Pattern pattern) {
+        try {
+            Document filterXml = XmlUtil.loadXml(filterFile);
+            Element workspaceFilterElement = filterXml.getDocumentElement();
+
+            return match(workspaceFilterElement, pattern);
+        } catch (Exception e) {
+            throw new MigrationRuntimeException(e);
+        }
+    }
+
+    public void removePath(String entry) {
+        try {
+            Document filterXml = XmlUtil.loadXml(filterFile);
+            Element workspaceFilterElement = filterXml.getDocumentElement();
+
+            List<Node> filterNodes = XmlUtil.getChildElementNodes(workspaceFilterElement);
+
+            for (Node currNode : filterNodes) {
+                String path = ((Element) currNode).getAttribute(MigrationConstants.ROOT_PROPERTY);
+                if (entry.equals(path)) {
+                    workspaceFilterElement.removeChild(currNode);
+                    XmlUtil.writeXml(filterXml, filterFile);
+                }
+            }
+
+        } catch (Exception e) {
+            throw new MigrationRuntimeException(e);
+        }
+    }
+
+
     private boolean hasEntry(Element workspaceFilterElement, String entry) {
         List<Node> filterNodes = XmlUtil.getChildElementNodes(workspaceFilterElement);
 
@@ -61,6 +108,21 @@ public class FilterFileDAO {
         }
 
         return matched;
+    }
+
+    private List<String> match(Element workspaceFilterElement, Pattern pattern) {
+        List<Node> filterNodes = XmlUtil.getChildElementNodes(workspaceFilterElement);
+
+        List<String> matches = new ArrayList<>();
+
+        for (Node currNode : filterNodes) {
+            String path = ((Element) currNode).getAttribute(MigrationConstants.ROOT_PROPERTY);
+            if (pattern.matcher(path).matches()) {
+                matches.add(path);
+            }
+        }
+
+        return matches;
     }
 
     private void addEntry(String path, Document filterXml, Element workspaceFilterElement) throws TransformerException, IOException {

--- a/src/main/java/com/adobe/skyline/migration/main/MigrationOrchestrator.java
+++ b/src/main/java/com/adobe/skyline/migration/main/MigrationOrchestrator.java
@@ -16,14 +16,24 @@ import java.io.File;
 import java.util.List;
 
 import com.adobe.skyline.migration.MigrationConstants;
-import com.adobe.skyline.migration.dao.*;
+import com.adobe.skyline.migration.dao.ContainerProjectDAO;
+import com.adobe.skyline.migration.dao.FilterFileDAO;
+import com.adobe.skyline.migration.dao.MavenProjectDAO;
+import com.adobe.skyline.migration.dao.ProcessingProfileDAO;
+import com.adobe.skyline.migration.dao.WorkflowLauncherDAO;
+import com.adobe.skyline.migration.dao.WorkflowModelDAO;
+import com.adobe.skyline.migration.dao.WorkflowRunnerConfigDAO;
 import com.adobe.skyline.migration.exception.CustomerDataException;
 import com.adobe.skyline.migration.exception.ProjectCreationException;
 import com.adobe.skyline.migration.model.ChangeTrackingService;
 import com.adobe.skyline.migration.model.workflow.Workflow;
 import com.adobe.skyline.migration.model.workflow.WorkflowProject;
 import com.adobe.skyline.migration.parser.CustomerProjectLoader;
-import com.adobe.skyline.migration.transformer.*;
+import com.adobe.skyline.migration.transformer.LauncherDisabler;
+import com.adobe.skyline.migration.transformer.MigrationReportWriter;
+import com.adobe.skyline.migration.transformer.ModelTransformer;
+import com.adobe.skyline.migration.transformer.VarNodeCleaner;
+import com.adobe.skyline.migration.transformer.WorkflowRunnerConfigCreator;
 import com.adobe.skyline.migration.transformer.processingprofile.ProcessingProfileCreator;
 import com.adobe.skyline.migration.transformer.processingprofile.ProfileMapperFactory;
 import com.adobe.skyline.migration.transformer.processingprofile.ProfileMapperFactoryImpl;
@@ -91,6 +101,10 @@ class MigrationOrchestrator {
                     runnerConfigCreator.createWorkflowConfigs(workflow);
                 }
             }
+
+            FilterFileDAO wfProjectFilterDAO = new FilterFileDAO(wfProject.getPath());
+            VarNodeCleaner varNodeCleaner = new VarNodeCleaner(wfProjectFilterDAO, changeTracker);
+            varNodeCleaner.cleanNodes(wfProject);
         }
 
         reportWriter.write(new File(reportOutputDirectory));

--- a/src/main/java/com/adobe/skyline/migration/model/ChangeTrackingService.java
+++ b/src/main/java/com/adobe/skyline/migration/model/ChangeTrackingService.java
@@ -12,7 +12,11 @@
 
 package com.adobe.skyline.migration.model;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ChangeTrackingService {
 
@@ -21,6 +25,7 @@ public class ChangeTrackingService {
     private Map<String, Map<String, WorkflowStepSupportStatus>> modelStepsModified;
     private List<ProcessingProfile> processingProfilesCreated;
     private List<String> projectsCreated;
+    private List<String> varPathsDeleted;
 
     public ChangeTrackingService() {
         this.disabledLaunchers = new ArrayList<>();
@@ -28,6 +33,7 @@ public class ChangeTrackingService {
         this.modelStepsModified = new HashMap<>();
         this.processingProfilesCreated = new ArrayList<>();
         this.projectsCreated = new ArrayList<>();
+        this.varPathsDeleted = new ArrayList<>();
     }
 
     public void trackLauncherDisabled(String launcherName) {
@@ -77,5 +83,13 @@ public class ChangeTrackingService {
 
     public List<String> getProjectsCreated() {
         return projectsCreated;
+    }
+
+    public void trackVarPathDeleted(String path) {
+        varPathsDeleted.add(path);
+    }
+
+    public List<String> getVarPathsDeleted() {
+        return varPathsDeleted;
     }
 }

--- a/src/main/java/com/adobe/skyline/migration/model/workflow/WorkflowModel.java
+++ b/src/main/java/com/adobe/skyline/migration/model/workflow/WorkflowModel.java
@@ -20,8 +20,6 @@ public class WorkflowModel {
 
     //Path to the workflow's Component node under /var/workflow or /etc
     private String runtimeComponent;
-    //File object that is referenced by the runtimeComponent path
-    private File runtimeFile;
 
     //Path to the workflow's configuration Page node under /conf or /etc
     private String configurationPage;
@@ -44,14 +42,6 @@ public class WorkflowModel {
 
     public void setRuntimeComponent(String workflowComponent) {
         this.runtimeComponent = workflowComponent;
-    }
-
-    public File getRuntimeFile() {
-        return runtimeFile;
-    }
-
-    public void setRuntimeFile(File runtimeFile) {
-        this.runtimeFile = runtimeFile;
     }
 
     public String getConfigurationPage() {

--- a/src/main/java/com/adobe/skyline/migration/model/workflow/WorkflowProject.java
+++ b/src/main/java/com/adobe/skyline/migration/model/workflow/WorkflowProject.java
@@ -17,10 +17,19 @@ import java.util.List;
 
 public class WorkflowProject {
 
+    private String path;
     private List<Workflow> workflows;
 
     public WorkflowProject() {
         this.workflows = new ArrayList<>();
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
     }
 
     public List<Workflow> getWorkflows() {

--- a/src/main/java/com/adobe/skyline/migration/parser/CustomerProjectLoader.java
+++ b/src/main/java/com/adobe/skyline/migration/parser/CustomerProjectLoader.java
@@ -13,11 +13,9 @@
 package com.adobe.skyline.migration.parser;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -25,7 +23,6 @@ import javax.xml.xpath.XPathFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import com.adobe.skyline.migration.MigrationConstants;
 import com.adobe.skyline.migration.dao.WorkflowLauncherDAO;
@@ -155,7 +152,7 @@ public class CustomerProjectLoader {
         return moduleNames;
     }
 
-    private boolean isContentPackage(Document moduleXml) throws CustomerDataException{
+    private boolean isContentPackage(Document moduleXml) {
         NodeList packagingNodes = moduleXml.getElementsByTagName(MigrationConstants.PACKAGING_TAG_NAME);
         if (packagingNodes.getLength() > 0) {
             String packaging = packagingNodes.item(0).getTextContent();
@@ -243,7 +240,7 @@ public class CustomerProjectLoader {
 
     private WorkflowProject createCustomerProject(String modulePath, List<String> wfLauncherPaths, List<String> workflowModelPaths) {
         WorkflowProject project = new WorkflowProject();
-
+        project.setPath(modulePath);
 
         WorkflowBuilder workflowBuilder = new WorkflowBuilder(launcherDAO, modelDAO, modulePath);
         List<Workflow> workflows = workflowBuilder.buildWorkflows(wfLauncherPaths, workflowModelPaths);
@@ -252,7 +249,7 @@ public class CustomerProjectLoader {
         return project;
     }
 
-    private boolean isContainerProject(Document moduleXml) throws ParserConfigurationException, SAXException, IOException, XPathExpressionException {
+    private boolean isContainerProject(Document moduleXml) throws XPathExpressionException {
         return hasEmbeddeds(moduleXml) && !hasPackageType(moduleXml);
     }
 

--- a/src/main/java/com/adobe/skyline/migration/transformer/MigrationReportWriter.java
+++ b/src/main/java/com/adobe/skyline/migration/transformer/MigrationReportWriter.java
@@ -46,6 +46,7 @@ public class MigrationReportWriter {
             writeLaunchersDisabled(reportFile);
             writeRunnerConfigs(reportFile);
             writeModifiedWorkflowSteps(reportFile);
+            writePathsDeleted(reportFile);
             writeProcessingProfiles(reportFile);
             writeProjects(reportFile);
         } catch (IOException e) {
@@ -163,6 +164,32 @@ public class MigrationReportWriter {
         }
 
         FileUtil.findAndReplaceInFile(reportFile, "\\$\\{WORKFLOW_MODELS_TRANSFORMED\\}", wfStepBuilder.toString());
+    }
+
+    private void writePathsDeleted(File reportFile) throws IOException {
+        StringBuilder mdBuilder = new StringBuilder();
+
+        if (changeTracker.getVarPathsDeleted().size() > 0) {
+            List<List<String>> tableValues = new LinkedList<>();
+
+            List<String> headerValues = new LinkedList<>(Arrays.asList("Action", "Path"));
+            tableValues.add(headerValues);
+            List<String> underlineRow = new LinkedList<>(Arrays.asList("------", "-------"));
+            tableValues.add(underlineRow);
+
+            for (String path : changeTracker.getVarPathsDeleted()) {
+                List<String> nextRow = new LinkedList<>(Arrays.asList("Deleted", path));
+                tableValues.add(nextRow);
+            }
+
+            String mdTable = createMarkdownTable(tableValues);
+            mdBuilder.append(mdTable);
+        } else {
+            mdBuilder.append(MigrationConstants.NO_PATHS_DELETED_MSG);
+            mdBuilder.append(System.getProperty("line.separator"));
+        }
+
+        FileUtil.findAndReplaceInFile(reportFile, "\\$\\{VAR_PATHS_DELETED\\}", mdBuilder.toString());
     }
 
     private void writeProcessingProfiles(File reportFile) throws IOException {

--- a/src/main/java/com/adobe/skyline/migration/transformer/VarNodeCleaner.java
+++ b/src/main/java/com/adobe/skyline/migration/transformer/VarNodeCleaner.java
@@ -1,0 +1,61 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+package com.adobe.skyline.migration.transformer;
+
+import java.io.File;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.adobe.skyline.migration.dao.FilterFileDAO;
+import com.adobe.skyline.migration.model.ChangeTrackingService;
+import com.adobe.skyline.migration.model.workflow.WorkflowProject;
+import com.adobe.skyline.migration.util.file.FileUtil;
+
+public class VarNodeCleaner {
+
+    private FilterFileDAO filterFileDao;
+    private ChangeTrackingService changeTrackingService;
+
+    public VarNodeCleaner(FilterFileDAO filterFileDao, ChangeTrackingService changeTrackingService) {
+        this.filterFileDao = filterFileDao;
+        this.changeTrackingService = changeTrackingService;
+    }
+
+    public void cleanNodes(WorkflowProject project) {
+        Pattern varMatcher = Pattern.compile("^/var/workflow.*");
+
+        List<String> varPaths = filterFileDao.findPathsWith(varMatcher);
+
+        for (String path : varPaths) {
+            filterFileDao.removePath(path);
+        }
+
+        if (varPaths.size() > 0) {
+            removeFromFilesystem(project);
+        }
+    }
+
+    private void removeFromFilesystem(WorkflowProject project) {
+        File varWorkflowRoot = new File(project.getPath() + "/src/main/content/jcr_root/var/workflow");
+        if (varWorkflowRoot.exists()) {
+            FileUtil.deleteRecursively(varWorkflowRoot);
+            File varRoot = varWorkflowRoot.getParentFile();
+            if (varRoot.listFiles().length == 0) {
+                varRoot.delete();
+                changeTrackingService.trackVarPathDeleted(varRoot.getPath());
+            } else {
+                changeTrackingService.trackVarPathDeleted(varWorkflowRoot.getPath());
+            }
+        }
+    }
+}

--- a/src/main/java/com/adobe/skyline/migration/util/file/FileUtil.java
+++ b/src/main/java/com/adobe/skyline/migration/util/file/FileUtil.java
@@ -12,7 +12,12 @@
 
 package com.adobe.skyline.migration.util.file;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Enumeration;
@@ -24,6 +29,20 @@ import java.util.jar.JarFile;
  * Utility for file-based CRUD operations
  */
 public class FileUtil {
+
+    public static void deleteRecursively(File file) {
+        File[] children = file.listFiles();
+
+        for (File child : children) {
+            if (child.isDirectory()) {
+                deleteRecursively(child);
+            } else {
+                child.delete();
+            }
+        }
+
+        file.delete();
+    }
 
     public static void copyDirectoryRecursively(File sourceFolder, File destinationFolder) throws IOException {
         if (sourceFolder.isDirectory())

--- a/src/main/resources/report-template.md
+++ b/src/main/resources/report-template.md
@@ -27,6 +27,10 @@ Many workflow models will combine Adobe-provided asset processing steps with cus
 We have made changes to the following workflow models:
 
 ${WORKFLOW_MODELS_TRANSFORMED}
+## Paths Deleted
+Workflow nodes under /var paths are no longer required for deployment to AEM as a Cloud Service.  These nodes will automatically be generated at system startup for any workflow models that have previously been synced.  In order to prevent potential deployment issues, the following /var paths have been removed from your Maven projects and filter files:
+
+${VAR_PATHS_DELETED}
 ## Asset Compute Service Processing Profiles
 By inspecting your workflow step configurations, we were able to automatically generate processing profiles for the Asset Compute Service to encompass configurations that you have customized.  These configurations can be found in the (`aem-cloud-migration.content`) project.
 

--- a/src/test/java/com/adobe/skyline/migration/transformer/VarNodeCleanerTest.java
+++ b/src/test/java/com/adobe/skyline/migration/transformer/VarNodeCleanerTest.java
@@ -1,0 +1,78 @@
+/*
+ Copyright 2020 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+package com.adobe.skyline.migration.transformer;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import com.adobe.skyline.migration.SkylineMigrationBaseTest;
+import com.adobe.skyline.migration.dao.FilterFileDAO;
+import com.adobe.skyline.migration.model.ChangeTrackingService;
+import com.adobe.skyline.migration.model.workflow.WorkflowProject;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.endsWith;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class VarNodeCleanerTest extends SkylineMigrationBaseTest {
+
+    @Mock FilterFileDAO filterFileDAO;
+
+    @Mock ChangeTrackingService changeTrackingService;
+
+    @Mock WorkflowProject workflowProject;
+
+    private File tempProjectRoot;
+
+    private VarNodeCleaner cleaner;
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        this.tempProjectRoot = projectLoader.copyConfProjectToTemp(temp);
+        when(workflowProject.getPath()).thenReturn(tempProjectRoot.getPath() + "/ui.content");
+        this.cleaner = new VarNodeCleaner(filterFileDAO, changeTrackingService);
+    }
+
+    @Test
+    public void testNoVarPathDoesntChangeAnything() {
+        when(filterFileDAO.findPathsWith(any())).thenReturn(new ArrayList<>());
+
+        cleaner.cleanNodes(workflowProject);
+
+        verify(filterFileDAO, never()).removePath(any());
+        verify(changeTrackingService, never()).trackVarPathDeleted(any());
+    }
+
+    @Test
+    public void testVarFilesDeleted() {
+        File varWorkflowDir = new File(tempProjectRoot, "ui.content/src/main/content/jcr_root/var/workflow");
+        assertTrue(varWorkflowDir.exists());
+        when(filterFileDAO.findPathsWith(any())).thenReturn(Arrays.asList("/var/workflow"));
+
+        cleaner.cleanNodes(workflowProject);
+
+        assertFalse(varWorkflowDir.exists());
+        verify(filterFileDAO).removePath("/var/workflow");
+        verify(changeTrackingService).trackVarPathDeleted(endsWith("ui.content/src/main/content/jcr_root/var/workflow"));
+    }
+}


### PR DESCRIPTION
Removing /var workflow nodes and removing the code that modifies and creates them.  These will now automatically be generated at system startup for all workflows that have been synced in the past.  Checking /var nodes into source control has been shown to lead to deployment issues for some customers.