### PR TITLE
CQ-4325360 : Improvements for workflow-migrator (Platform Independence)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,5 +110,10 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
+++ b/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
@@ -13,7 +13,7 @@
 package com.adobe.skyline.migration;
 
 import java.io.File;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -54,7 +54,7 @@ public final class MigrationConstants {
     public static final String CONTENT_DAM_PATH = "/" + CONTENT + "/" + DAM;
     public static final String COLLECTIONS = "collections";
     public static final String METADATA = "metadata";
-    public static final String MIGRATION_PACKAGE_PATH = Paths.get("", "apps", "aem-cloud-migration-packages").toString();
+    public static final String MIGRATION_PACKAGE_PATH = Path.of("", "apps", "aem-cloud-migration-packages").toString();
 
     //Filter File Constants
     public static final String FILTER_XML = "filter.xml";
@@ -77,9 +77,9 @@ public final class MigrationConstants {
     public static final String PACKAGING_TAG_NAME = "packaging";
     public static final String CONTENT_PACKAGE_PACKAGING = "content-package";
     public static final String CONTENT_XML = ".content.xml";
-    public static final String PATH_TO_CONTENT = Paths.get("", SRC, MAIN, CONTENT).toString();
-    public static final String PATH_TO_FILTER_XML = Paths.get(PATH_TO_CONTENT, META_INF, VAULT, FILTER_XML).toString();
-    public static final String PATH_TO_JCR_ROOT = Paths.get(PATH_TO_CONTENT, JCR_ROOT_ON_DISK).toString();
+    public static final String PATH_TO_CONTENT = Path.of("", SRC, MAIN, CONTENT).toString();
+    public static final String PATH_TO_FILTER_XML = Path.of(PATH_TO_CONTENT, META_INF, VAULT, FILTER_XML).toString();
+    public static final String PATH_TO_JCR_ROOT = Path.of(PATH_TO_CONTENT, JCR_ROOT_ON_DISK).toString();
 
     public static final String MIGRATION_PROJECT_BASE_NAME = "aem-cloud-migration";
     public static final String MIGRATION_PROJECT_CONTENT = MIGRATION_PROJECT_BASE_NAME + ".content";
@@ -93,8 +93,8 @@ public final class MigrationConstants {
     public static final String MODEL_XML = "model.xml";
 
     //Workflow Launcher Constants
-    public static final String PATH_TO_CONF_GLOBAL_LAUNCHER_CONFIG = File.separator + Paths.get(PATH_TO_JCR_ROOT, CONF, GLOBAL,  SETTINGS, WORKFLOW, LAUNCHER, CONFIG).toString();
-    public static final String PATH_TO_ETC_LAUNCHER_CONFIG = File.separator + Paths.get(PATH_TO_JCR_ROOT, ETC, WORKFLOW, LAUNCHER, CONFIG).toString();
+    public static final String PATH_TO_CONF_GLOBAL_LAUNCHER_CONFIG = File.separator + Path.of(PATH_TO_JCR_ROOT, CONF, GLOBAL,  SETTINGS, WORKFLOW, LAUNCHER, CONFIG).toString();
+    public static final String PATH_TO_ETC_LAUNCHER_CONFIG = File.separator + Path.of(PATH_TO_JCR_ROOT, ETC, WORKFLOW, LAUNCHER, CONFIG).toString();
     public static final String ORIGINAL_RENDITION_PATTERN_SUFFIX = "renditions/original";
 
     //Workflow Runner Constants
@@ -104,8 +104,8 @@ public final class MigrationConstants {
     public static final String WORKFLOW_RUNNER_CONFIG_BY_PATH = "postProcWorkflowsByPath";
 
     //Processing Profile Constants
-    public static final String PROCESSING_PROFILE_JCR_PATH = Paths.get(CONF, GLOBAL, SETTINGS, DAM, PROCESSING).toString();
-    public static final String PROCESSING_PROFILE_DISK_PATH = Paths.get(PATH_TO_JCR_ROOT, PROCESSING_PROFILE_JCR_PATH).toString();
+    public static final String PROCESSING_PROFILE_JCR_PATH = Path.of(CONF, GLOBAL, SETTINGS, DAM, PROCESSING).toString();
+    public static final String PROCESSING_PROFILE_DISK_PATH = Path.of(PATH_TO_JCR_ROOT, PROCESSING_PROFILE_JCR_PATH).toString();
     public static final String PROCESSING_PROFILE_RESOURCE_TYPE = "dam/processing/profile";
     public static final String RENDITION_RESOURCE_TYPE = "dam/processing/profile/rendition";
     public static final String INCLUDE_MIMETYPES_PROP = "includeMimeTypes";

--- a/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
+++ b/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
@@ -13,6 +13,7 @@
 package com.adobe.skyline.migration;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -22,7 +23,7 @@ import java.util.Map;
 import com.adobe.skyline.migration.model.workflow.WorkflowLauncher;
 import com.adobe.skyline.migration.model.workflow.WorkflowStep;
 
-public class MigrationConstants {
+public final class MigrationConstants {
 
     //Node Name Constants
     public static final String VAR = "var";
@@ -53,7 +54,7 @@ public class MigrationConstants {
     public static final String CONTENT_DAM_PATH = "/" + CONTENT + "/" + DAM;
     public static final String COLLECTIONS = "collections";
     public static final String METADATA = "metadata";
-    public static final String MIGRATION_PACKAGE_PATH = "/apps/aem-cloud-migration-packages";
+    public static final String MIGRATION_PACKAGE_PATH = Paths.get("", "apps", "aem-cloud-migration-packages").toString();
 
     //Filter File Constants
     public static final String FILTER_XML = "filter.xml";
@@ -76,9 +77,9 @@ public class MigrationConstants {
     public static final String PACKAGING_TAG_NAME = "packaging";
     public static final String CONTENT_PACKAGE_PACKAGING = "content-package";
     public static final String CONTENT_XML = ".content.xml";
-    public static final String PATH_TO_CONTENT = "/" + SRC + "/" + MAIN + "/" + CONTENT;
-    public static final String PATH_TO_FILTER_XML = PATH_TO_CONTENT + "/" + META_INF + "/" + VAULT + "/" + FILTER_XML;
-    public static final String PATH_TO_JCR_ROOT = PATH_TO_CONTENT + "/" + JCR_ROOT_ON_DISK;
+    public static final String PATH_TO_CONTENT = Paths.get("", SRC, MAIN, CONTENT).toString();
+    public static final String PATH_TO_FILTER_XML = Paths.get(PATH_TO_CONTENT, META_INF, VAULT, FILTER_XML).toString();
+    public static final String PATH_TO_JCR_ROOT = Paths.get(PATH_TO_CONTENT, JCR_ROOT_ON_DISK).toString();
 
     public static final String MIGRATION_PROJECT_BASE_NAME = "aem-cloud-migration";
     public static final String MIGRATION_PROJECT_CONTENT = MIGRATION_PROJECT_BASE_NAME + ".content";
@@ -92,19 +93,19 @@ public class MigrationConstants {
     public static final String MODEL_XML = "model.xml";
 
     //Workflow Launcher Constants
-    public static final String PATH_TO_CONF_GLOBAL_LAUNCHER_CONFIG = PATH_TO_JCR_ROOT + CONF_ROOT + File.separator + GLOBAL + File.separator + SETTINGS + File.separator + WORKFLOW + File.separator + LAUNCHER + File.separator + CONFIG;
-    public static final String PATH_TO_ETC_LAUNCHER_CONFIG = PATH_TO_JCR_ROOT + ETC_PATH + File.separator + LAUNCHER + File.separator + CONFIG;
+    public static final String PATH_TO_CONF_GLOBAL_LAUNCHER_CONFIG = File.separator + Paths.get(PATH_TO_JCR_ROOT, CONF, GLOBAL,  SETTINGS, WORKFLOW, LAUNCHER, CONFIG).toString();
+    public static final String PATH_TO_ETC_LAUNCHER_CONFIG = File.separator + Paths.get(PATH_TO_JCR_ROOT, ETC, WORKFLOW, LAUNCHER, CONFIG).toString();
     public static final String ORIGINAL_RENDITION_PATTERN_SUFFIX = "renditions/original";
 
     //Workflow Runner Constants
-    public static final String WORKFLOW_RUNNER_CONFIG_PATH = "/" + APPS + "/" + MIGRATION_PROJECT_NODE + "/" + CONFIG;
+    public static final String WORKFLOW_RUNNER_CONFIG_PATH = Paths.get("", APPS, MIGRATION_PROJECT_NODE, CONFIG).toString();
     public static final String WORKFLOW_RUNNER_CONFIG_FILENAME = "com.adobe.cq.dam.processor.nui.impl.workflow.CustomDamWorkflowRunnerImpl.xml";
     public static final String WORKFLOW_RUNNER_CONFIG_BY_EXPRESSION = "postProcWorkflowsByExpression";
     public static final String WORKFLOW_RUNNER_CONFIG_BY_PATH = "postProcWorkflowsByPath";
 
     //Processing Profile Constants
-    public static final String PROCESSING_PROFILE_JCR_PATH = CONF_ROOT + File.separator + GLOBAL + File.separator + SETTINGS + File.separator + DAM + File.separator + PROCESSING;
-    public static final String PROCESSING_PROFILE_DISK_PATH = PATH_TO_JCR_ROOT + PROCESSING_PROFILE_JCR_PATH;
+    public static final String PROCESSING_PROFILE_JCR_PATH = Paths.get(CONF, GLOBAL, SETTINGS, DAM, PROCESSING).toString();
+    public static final String PROCESSING_PROFILE_DISK_PATH = Paths.get(PATH_TO_JCR_ROOT, PROCESSING_PROFILE_JCR_PATH).toString();
     public static final String PROCESSING_PROFILE_RESOURCE_TYPE = "dam/processing/profile";
     public static final String RENDITION_RESOURCE_TYPE = "dam/processing/profile/rendition";
     public static final String INCLUDE_MIMETYPES_PROP = "includeMimeTypes";
@@ -195,11 +196,11 @@ public class MigrationConstants {
     public static final String DELETE_PREVIEW_PROCESS = "com.day.cq.dam.core.process.DeleteImagePreviewProcess";
 
     public static final Map<String, WorkflowLauncher> DEFAULT_ENABLED_MODELS = new HashMap<>() {{
-        put("dam/batch-thumbnails", buildWorkflowLauncher("/var/dam/pending-thumbs(/.*)", Arrays.asList("paths!=")));
-        put("dam/dynamic-media-encode-video", buildWorkflowLauncher("/content/dam(/.*/)renditions/original", Arrays.asList("jcr:content/jcr:mimeType==video/.*")));
-        put("dam/process_subasset", buildWorkflowLauncher("/content/dam(/.*/)(subassets)(/.*/)renditions/original", Arrays.asList("jcr:content/jcr:mimeType!=video/.*")));
-        put("dam/update_asset", buildWorkflowLauncher("/content/dam(/((?!/subassets).)*/)renditions/original", new ArrayList<>()));
-        put("dam/update_from_lightbox", buildWorkflowLauncher("/var/lightbox", new ArrayList<>()));
+        put("batch-thumbnails", buildWorkflowLauncher("/var/dam/pending-thumbs(/.*)", Arrays.asList("paths!=")));
+        put("dynamic-media-encode-video", buildWorkflowLauncher("/content/dam(/.*/)renditions/original", Arrays.asList("jcr:content/jcr:mimeType==video/.*")));
+        put("process_subasset", buildWorkflowLauncher("/content/dam(/.*/)(subassets)(/.*/)renditions/original", Arrays.asList("jcr:content/jcr:mimeType!=video/.*")));
+        put("update_asset", buildWorkflowLauncher("/content/dam(/((?!/subassets).)*/)renditions/original", new ArrayList<>()));
+        put("update_from_lightbox", buildWorkflowLauncher("/var/lightbox", new ArrayList<>()));
     }};
 
     //Object Constants

--- a/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
+++ b/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
@@ -98,7 +98,7 @@ public final class MigrationConstants {
     public static final String ORIGINAL_RENDITION_PATTERN_SUFFIX = "renditions/original";
 
     //Workflow Runner Constants
-    public static final String WORKFLOW_RUNNER_CONFIG_PATH = Paths.get("", APPS, MIGRATION_PROJECT_NODE, CONFIG).toString();
+    public static final String WORKFLOW_RUNNER_CONFIG_PATH = "/" + APPS + "/" + MIGRATION_PROJECT_NODE + "/" + CONFIG;
     public static final String WORKFLOW_RUNNER_CONFIG_FILENAME = "com.adobe.cq.dam.processor.nui.impl.workflow.CustomDamWorkflowRunnerImpl.xml";
     public static final String WORKFLOW_RUNNER_CONFIG_BY_EXPRESSION = "postProcWorkflowsByExpression";
     public static final String WORKFLOW_RUNNER_CONFIG_BY_PATH = "postProcWorkflowsByPath";

--- a/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
+++ b/src/main/java/com/adobe/skyline/migration/MigrationConstants.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import com.adobe.skyline.migration.model.workflow.WorkflowLauncher;
 import com.adobe.skyline.migration.model.workflow.WorkflowStep;
 
-public final class MigrationConstants {
+public class MigrationConstants {
 
     //Node Name Constants
     public static final String VAR = "var";
@@ -54,8 +54,7 @@ public final class MigrationConstants {
     public static final String CONTENT_DAM_PATH = "/" + CONTENT + "/" + DAM;
     public static final String COLLECTIONS = "collections";
     public static final String METADATA = "metadata";
-    public static final String MIGRATION_PACKAGE_PATH = Path.of("", "apps", "aem-cloud-migration-packages").toString();
-
+    public static final String MIGRATION_PACKAGE_PATH = "/apps/aem-cloud-migration-packages";
     //Filter File Constants
     public static final String FILTER_XML = "filter.xml";
     public static final String FILTER_TAG_NAME = "filter";

--- a/src/main/java/com/adobe/skyline/migration/dao/FilterFileDAO.java
+++ b/src/main/java/com/adobe/skyline/migration/dao/FilterFileDAO.java
@@ -14,7 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -37,7 +37,7 @@ public class FilterFileDAO {
     private File filterFile;
 
     public FilterFileDAO(String projectPath) {
-        this.filterFile = new File(Paths.get(projectPath, MigrationConstants.PATH_TO_FILTER_XML).toString());
+        this.filterFile = new File(Path.of(projectPath, MigrationConstants.PATH_TO_FILTER_XML).toString());
     }
 
     public boolean hasPath(String path) {

--- a/src/main/java/com/adobe/skyline/migration/dao/FilterFileDAO.java
+++ b/src/main/java/com/adobe/skyline/migration/dao/FilterFileDAO.java
@@ -14,6 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -36,7 +37,7 @@ public class FilterFileDAO {
     private File filterFile;
 
     public FilterFileDAO(String projectPath) {
-        this.filterFile = new File(projectPath + MigrationConstants.PATH_TO_FILTER_XML);
+        this.filterFile = new File(Paths.get(projectPath, MigrationConstants.PATH_TO_FILTER_XML).toString());
     }
 
     public boolean hasPath(String path) {

--- a/src/main/java/com/adobe/skyline/migration/dao/MavenProjectDAO.java
+++ b/src/main/java/com/adobe/skyline/migration/dao/MavenProjectDAO.java
@@ -14,6 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.jar.JarFile;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -61,7 +62,7 @@ public class MavenProjectDAO {
      * Check to see if a project already exists.  This is used to determine whether it should be created.
      */
     public boolean projectExists(String projectName) {
-        String fullPath = this.existingProjectPath + File.separator + projectName;
+        String fullPath = Paths.get(this.existingProjectPath, projectName).toString();
         return (new File(fullPath)).exists();
     }
 
@@ -70,7 +71,7 @@ public class MavenProjectDAO {
      */
     public void createProject(String projectName) throws ProjectCreationException {
         try {
-            String targetPath = this.existingProjectPath + File.separator + projectName;
+            String targetPath = Paths.get(this.existingProjectPath, projectName).toString();
             String templatePath = "";
 
             if (projectName.equals(MigrationConstants.MIGRATION_PROJECT_CONTENT)) {

--- a/src/main/java/com/adobe/skyline/migration/dao/MavenProjectDAO.java
+++ b/src/main/java/com/adobe/skyline/migration/dao/MavenProjectDAO.java
@@ -14,7 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.jar.JarFile;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -62,7 +62,7 @@ public class MavenProjectDAO {
      * Check to see if a project already exists.  This is used to determine whether it should be created.
      */
     public boolean projectExists(String projectName) {
-        String fullPath = Paths.get(this.existingProjectPath, projectName).toString();
+        String fullPath = Path.of(this.existingProjectPath, projectName).toString();
         return (new File(fullPath)).exists();
     }
 
@@ -71,7 +71,7 @@ public class MavenProjectDAO {
      */
     public void createProject(String projectName) throws ProjectCreationException {
         try {
-            String targetPath = Paths.get(this.existingProjectPath, projectName).toString();
+            String targetPath = Path.of(this.existingProjectPath, projectName).toString();
             String templatePath = "";
 
             if (projectName.equals(MigrationConstants.MIGRATION_PROJECT_CONTENT)) {

--- a/src/main/java/com/adobe/skyline/migration/dao/WorkflowModelDAO.java
+++ b/src/main/java/com/adobe/skyline/migration/dao/WorkflowModelDAO.java
@@ -14,7 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,7 +45,7 @@ public class WorkflowModelDAO {
     public WorkflowModel loadWorkflowModel(String moduleAbsoluteRoot, String workflowModelPath) throws CustomerDataException {
         Logger.DEBUG("workflowModelPath: " + workflowModelPath);
 
-        String codeRoot = Paths.get(moduleAbsoluteRoot, MigrationConstants.PATH_TO_JCR_ROOT).toString();
+        String codeRoot = Path.of(moduleAbsoluteRoot, MigrationConstants.PATH_TO_JCR_ROOT).toString();
 
         String varPath = "";
         String confPath = "";
@@ -91,7 +91,7 @@ public class WorkflowModelDAO {
         Logger.DEBUG("codeRoot: " + codeRoot);
         Logger.DEBUG("confPath: " + confPath);
 
-        File confFile = new File(Paths.get(codeRoot, confPath, MigrationConstants.CONTENT_XML).toString());
+        File confFile = new File(Path.of(codeRoot, confPath, MigrationConstants.CONTENT_XML).toString());
 
         Logger.DEBUG("confFile path: " + confFile.getPath());
 

--- a/src/main/java/com/adobe/skyline/migration/dao/WorkflowModelDAO.java
+++ b/src/main/java/com/adobe/skyline/migration/dao/WorkflowModelDAO.java
@@ -14,6 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,7 +45,7 @@ public class WorkflowModelDAO {
     public WorkflowModel loadWorkflowModel(String moduleAbsoluteRoot, String workflowModelPath) throws CustomerDataException {
         Logger.DEBUG("workflowModelPath: " + workflowModelPath);
 
-        String codeRoot = moduleAbsoluteRoot + MigrationConstants.PATH_TO_JCR_ROOT;
+        String codeRoot = Paths.get(moduleAbsoluteRoot, MigrationConstants.PATH_TO_JCR_ROOT).toString();
 
         String varPath = "";
         String confPath = "";
@@ -90,7 +91,7 @@ public class WorkflowModelDAO {
         Logger.DEBUG("codeRoot: " + codeRoot);
         Logger.DEBUG("confPath: " + confPath);
 
-        File confFile = new File(codeRoot + confPath + File.separator +  MigrationConstants.CONTENT_XML);
+        File confFile = new File(Paths.get(codeRoot, confPath, MigrationConstants.CONTENT_XML).toString());
 
         Logger.DEBUG("confFile path: " + confFile.getPath());
 

--- a/src/main/java/com/adobe/skyline/migration/dao/WorkflowRunnerConfigDAO.java
+++ b/src/main/java/com/adobe/skyline/migration/dao/WorkflowRunnerConfigDAO.java
@@ -36,7 +36,7 @@ public class WorkflowRunnerConfigDAO {
     private Document configDoc;
 
     public WorkflowRunnerConfigDAO(String projectPath) {
-        this.configFile = new File(Paths.get(projectPath ,MigrationConstants.PATH_TO_JCR_ROOT,
+        this.configFile = new File(Paths.get(projectPath, MigrationConstants.PATH_TO_JCR_ROOT,
                 MigrationConstants.WORKFLOW_RUNNER_CONFIG_PATH, MigrationConstants.WORKFLOW_RUNNER_CONFIG_FILENAME).toString());
     }
 

--- a/src/main/java/com/adobe/skyline/migration/dao/WorkflowRunnerConfigDAO.java
+++ b/src/main/java/com/adobe/skyline/migration/dao/WorkflowRunnerConfigDAO.java
@@ -14,10 +14,10 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
 
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
@@ -36,8 +36,8 @@ public class WorkflowRunnerConfigDAO {
     private Document configDoc;
 
     public WorkflowRunnerConfigDAO(String projectPath) {
-        this.configFile = new File(projectPath + MigrationConstants.PATH_TO_JCR_ROOT +
-                MigrationConstants.WORKFLOW_RUNNER_CONFIG_PATH + "/" + MigrationConstants.WORKFLOW_RUNNER_CONFIG_FILENAME);
+        this.configFile = new File(Paths.get(projectPath ,MigrationConstants.PATH_TO_JCR_ROOT,
+                MigrationConstants.WORKFLOW_RUNNER_CONFIG_PATH, MigrationConstants.WORKFLOW_RUNNER_CONFIG_FILENAME).toString());
     }
 
     public void createConfigByExpression(String expression, String model) {

--- a/src/main/java/com/adobe/skyline/migration/main/MigrationOrchestrator.java
+++ b/src/main/java/com/adobe/skyline/migration/main/MigrationOrchestrator.java
@@ -13,6 +13,7 @@
 package com.adobe.skyline.migration.main;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 
 import com.adobe.skyline.migration.MigrationConstants;
@@ -65,10 +66,10 @@ class MigrationOrchestrator {
         //Initialize Data Access Objects
         WorkflowLauncherDAO launcherDAO = new WorkflowLauncherDAO();
         WorkflowModelDAO modelDAO = new WorkflowModelDAO();
-        FilterFileDAO appsFilterDAO = new FilterFileDAO(customerProjectPath + "/" + MigrationConstants.MIGRATION_PROJECT_APPS);
-        FilterFileDAO contentFilterDAO = new FilterFileDAO(customerProjectPath + "/" + MigrationConstants.MIGRATION_PROJECT_CONTENT);
-        ProcessingProfileDAO ppDAO = new ProcessingProfileDAO(customerProjectPath + "/" + MigrationConstants.MIGRATION_PROJECT_CONTENT);
-        WorkflowRunnerConfigDAO runnerConfigDAO = new WorkflowRunnerConfigDAO(customerProjectPath + "/" + MigrationConstants.MIGRATION_PROJECT_APPS);
+        FilterFileDAO appsFilterDAO = new FilterFileDAO(Paths.get(customerProjectPath, MigrationConstants.MIGRATION_PROJECT_APPS).toString());
+        FilterFileDAO contentFilterDAO = new FilterFileDAO(Paths.get(customerProjectPath, MigrationConstants.MIGRATION_PROJECT_CONTENT).toString());
+        ProcessingProfileDAO ppDAO = new ProcessingProfileDAO(Paths.get(customerProjectPath, MigrationConstants.MIGRATION_PROJECT_CONTENT).toString());
+        WorkflowRunnerConfigDAO runnerConfigDAO = new WorkflowRunnerConfigDAO(Paths.get(customerProjectPath, MigrationConstants.MIGRATION_PROJECT_APPS).toString());
 
         //Load customer projects
         CustomerProjectLoader loader = new CustomerProjectLoader(queryService, launcherDAO, modelDAO);
@@ -108,6 +109,6 @@ class MigrationOrchestrator {
         }
 
         reportWriter.write(new File(reportOutputDirectory));
-        Logger.INFO("Migration complete.  A report file has been created at " + reportOutputDirectory + File.separator + MigrationConstants.REPORT_FILENAME + ".");
+        Logger.INFO("Migration complete.  A report file has been created at " + Paths.get(reportOutputDirectory, MigrationConstants.REPORT_FILENAME, ".").toString());
     }
 }

--- a/src/main/java/com/adobe/skyline/migration/parser/WorkflowBuilder.java
+++ b/src/main/java/com/adobe/skyline/migration/parser/WorkflowBuilder.java
@@ -22,6 +22,7 @@ import com.adobe.skyline.migration.model.workflow.Workflow;
 import com.adobe.skyline.migration.model.workflow.WorkflowLauncher;
 import com.adobe.skyline.migration.model.workflow.WorkflowModel;
 import com.adobe.skyline.migration.util.Logger;
+import org.apache.commons.io.FilenameUtils;
 
 /**
  * Leveraged by the CustomerProjectLoader to create Workflow model objects from the customer workflow configurations.
@@ -122,11 +123,9 @@ class WorkflowBuilder {
     }
 
     private String getModelName(String modelPath) {
-        return modelPath
-                .replaceAll(".*/conf/global/settings/workflow/models/", "")
-                .replaceAll(".*/var/workflow/models/", "")
-                .replaceAll(".*/etc/workflow/models/", "")
+        modelPath =  modelPath
                 .replaceAll("/jcr:content/model", "")
                 .replaceAll("/.content.xml", "");
+        return FilenameUtils.getBaseName(modelPath);
     }
 }

--- a/src/test/java/com/adobe/skyline/migration/dao/ContainerProjectDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/ContainerProjectDAOTest.java
@@ -14,6 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -50,14 +51,14 @@ public class ContainerProjectDAOTest extends SkylineMigrationBaseTest {
     @Test
     public void testNewProjectsAddedToAllProjectWhenPresent() throws ParserConfigurationException, SAXException, IOException {
         File tempProjectRoot = projectLoader.copyMigratedProjectToTemp(temp);
-        ContainerProjectDAO dao = new ContainerProjectDAO(tempProjectRoot.getAbsolutePath() + "/" +
-                TestConstants.CONTAINER_PACKAGE_PROJECT_NAME);
+        ContainerProjectDAO dao = new ContainerProjectDAO(Paths.get(tempProjectRoot.getAbsolutePath(),
+                TestConstants.CONTAINER_PACKAGE_PROJECT_NAME).toString());
 
         dao.addProject(TestConstants.TEST_PROJECT_GROUP_ID, MigrationConstants.MIGRATION_PROJECT_CONTENT);
         dao.addProject(TestConstants.TEST_PROJECT_GROUP_ID, MigrationConstants.MIGRATION_PROJECT_APPS);
 
-        File allPom = new File(tempProjectRoot + "/" + TestConstants.CONTAINER_PACKAGE_PROJECT_NAME,
-                MigrationConstants.POM_XML);
+        File allPom = new File(Paths.get(tempProjectRoot.getPath(), TestConstants.CONTAINER_PACKAGE_PROJECT_NAME,
+                MigrationConstants.POM_XML).toString());
         Document doc = XmlUtil.loadXml(allPom);
 
         assertArtifactInEmbeddeds(MigrationConstants.MIGRATION_PROJECT_CONTENT, doc);
@@ -69,13 +70,13 @@ public class ContainerProjectDAOTest extends SkylineMigrationBaseTest {
     @Test
     public void testFilterAdded() throws ParserConfigurationException, SAXException, IOException {
         File tempProjectRoot = projectLoader.copyMigratedProjectToTemp(temp);
-        ContainerProjectDAO dao = new ContainerProjectDAO(tempProjectRoot.getAbsolutePath() + "/" +
-                TestConstants.CONTAINER_PACKAGE_PROJECT_NAME);
+        ContainerProjectDAO dao = new ContainerProjectDAO(Paths.get(tempProjectRoot.getAbsolutePath(),
+                TestConstants.CONTAINER_PACKAGE_PROJECT_NAME).toString());
 
         dao.addProject(TestConstants.TEST_PROJECT_GROUP_ID, MigrationConstants.MIGRATION_PROJECT_CONTENT);
 
-        File filterFile = new File(tempProjectRoot + "/" + TestConstants.CONTAINER_PACKAGE_PROJECT_NAME +
-                MigrationConstants.PATH_TO_FILTER_XML);
+        File filterFile = new File(Paths.get(tempProjectRoot.getPath(), TestConstants.CONTAINER_PACKAGE_PROJECT_NAME,
+                MigrationConstants.PATH_TO_FILTER_XML).toString());
 
         Document filterXml = XmlUtil.loadXml(filterFile);
         Element workspaceFilterElement = filterXml.getDocumentElement();

--- a/src/test/java/com/adobe/skyline/migration/dao/ContainerProjectDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/ContainerProjectDAOTest.java
@@ -14,7 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -51,13 +51,13 @@ public class ContainerProjectDAOTest extends SkylineMigrationBaseTest {
     @Test
     public void testNewProjectsAddedToAllProjectWhenPresent() throws ParserConfigurationException, SAXException, IOException {
         File tempProjectRoot = projectLoader.copyMigratedProjectToTemp(temp);
-        ContainerProjectDAO dao = new ContainerProjectDAO(Paths.get(tempProjectRoot.getAbsolutePath(),
+        ContainerProjectDAO dao = new ContainerProjectDAO(Path.of(tempProjectRoot.getAbsolutePath(),
                 TestConstants.CONTAINER_PACKAGE_PROJECT_NAME).toString());
 
         dao.addProject(TestConstants.TEST_PROJECT_GROUP_ID, MigrationConstants.MIGRATION_PROJECT_CONTENT);
         dao.addProject(TestConstants.TEST_PROJECT_GROUP_ID, MigrationConstants.MIGRATION_PROJECT_APPS);
 
-        File allPom = new File(Paths.get(tempProjectRoot.getPath(), TestConstants.CONTAINER_PACKAGE_PROJECT_NAME,
+        File allPom = new File(Path.of(tempProjectRoot.getPath(), TestConstants.CONTAINER_PACKAGE_PROJECT_NAME,
                 MigrationConstants.POM_XML).toString());
         Document doc = XmlUtil.loadXml(allPom);
 
@@ -70,12 +70,12 @@ public class ContainerProjectDAOTest extends SkylineMigrationBaseTest {
     @Test
     public void testFilterAdded() throws ParserConfigurationException, SAXException, IOException {
         File tempProjectRoot = projectLoader.copyMigratedProjectToTemp(temp);
-        ContainerProjectDAO dao = new ContainerProjectDAO(Paths.get(tempProjectRoot.getAbsolutePath(),
+        ContainerProjectDAO dao = new ContainerProjectDAO(Path.of(tempProjectRoot.getAbsolutePath(),
                 TestConstants.CONTAINER_PACKAGE_PROJECT_NAME).toString());
 
         dao.addProject(TestConstants.TEST_PROJECT_GROUP_ID, MigrationConstants.MIGRATION_PROJECT_CONTENT);
 
-        File filterFile = new File(Paths.get(tempProjectRoot.getPath(), TestConstants.CONTAINER_PACKAGE_PROJECT_NAME,
+        File filterFile = new File(Path.of(tempProjectRoot.getPath(), TestConstants.CONTAINER_PACKAGE_PROJECT_NAME,
                 MigrationConstants.PATH_TO_FILTER_XML).toString());
 
         Document filterXml = XmlUtil.loadXml(filterFile);

--- a/src/test/java/com/adobe/skyline/migration/dao/FilterFileDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/FilterFileDAOTest.java
@@ -14,6 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -46,9 +47,9 @@ public class FilterFileDAOTest extends SkylineMigrationBaseTest {
         super.setUp();
 
         this.tempProjectRoot = projectLoader.copyConfProjectToTemp(temp);
-        this.filterFile = new File(tempProjectRoot + File.separator + TestConstants.CONF_WORKFLOW_PROJECT_NAME + MigrationConstants.PATH_TO_FILTER_XML);
+        this.filterFile = new File(Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME, MigrationConstants.PATH_TO_FILTER_XML).toString());
 
-        this.dao = new FilterFileDAO(tempProjectRoot + File.separator + TestConstants.CONF_WORKFLOW_PROJECT_NAME);
+        this.dao = new FilterFileDAO(Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME).toString());
     }
 
     @Test

--- a/src/test/java/com/adobe/skyline/migration/dao/FilterFileDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/FilterFileDAOTest.java
@@ -14,7 +14,7 @@ package com.adobe.skyline.migration.dao;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -47,9 +47,9 @@ public class FilterFileDAOTest extends SkylineMigrationBaseTest {
         super.setUp();
 
         this.tempProjectRoot = projectLoader.copyConfProjectToTemp(temp);
-        this.filterFile = new File(Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME, MigrationConstants.PATH_TO_FILTER_XML).toString());
+        this.filterFile = new File(Path.of(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME, MigrationConstants.PATH_TO_FILTER_XML).toString());
 
-        this.dao = new FilterFileDAO(Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME).toString());
+        this.dao = new FilterFileDAO(Path.of(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME).toString());
     }
 
     @Test

--- a/src/test/java/com/adobe/skyline/migration/dao/ProcessingProfileDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/ProcessingProfileDAOTest.java
@@ -28,7 +28,7 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -48,14 +48,14 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
         super.setUp();
 
         File tempProjectRoot = projectLoader.copyConfProjectToTemp(temp);
-        this.projectRootPath = Paths.get(tempProjectRoot.toString(), TestConstants.CONF_WORKFLOW_PROJECT_NAME).toString();
+        this.projectRootPath = Path.of(tempProjectRoot.toString(), TestConstants.CONF_WORKFLOW_PROJECT_NAME).toString();
 
         this.dao = new ProcessingProfileDAO(projectRootPath);
     }
 
     @Test
     public void testProcessingRootPageCreated() throws ParserConfigurationException, SAXException, IOException {
-        File profileRootFile = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, ".content.xml").toString());
+        File profileRootFile = new File(Path.of(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, ".content.xml").toString());
         assertFalse(profileRootFile.exists());
 
         ProcessingProfile profile = createTestProfile();
@@ -82,7 +82,7 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
 
     @Test
     public void testProfileAdded() throws ParserConfigurationException, SAXException, IOException {
-        File profilePath = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME).toString());
+        File profilePath = new File(Path.of(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME).toString());
         assertFalse(profilePath.exists());
 
         ProcessingProfile profile = createTestProfile();
@@ -142,7 +142,7 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
 
     @Test
     public void testEmptyMimetypesIncluded() throws ParserConfigurationException, SAXException, IOException {
-        File profilePath = new File(Paths.get(projectRootPath,MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME).toString());
+        File profilePath = new File(Path.of(projectRootPath,MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME).toString());
 
         RenditionConfig renditionConfig1 = createThumbnailRendition();
         ProcessingProfile profile = new ProcessingProfile();
@@ -178,9 +178,9 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
 
     @Test
     public void testDuplicateProfileNames() {
-        File profile1Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME).toString());
-        File profile2Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME + "-1").toString());
-        File profile3Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME + "-2").toString());
+        File profile1Path = new File(Path.of(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME).toString());
+        File profile2Path = new File(Path.of(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME + "-1").toString());
+        File profile3Path = new File(Path.of(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME + "-2").toString());
 
         assertFalse(profile1Path.exists());
         assertFalse(profile2Path.exists());
@@ -212,9 +212,9 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
 
         dao.addProfile(profile);
 
-        File rendition1Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME, "thumbnail").toString());
+        File rendition1Path = new File(Path.of(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME, "thumbnail").toString());
         assertTrue(rendition1Path.exists());
-        File rendition2Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME, "thumbnail-1").toString());
+        File rendition2Path = new File(Path.of(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME, "thumbnail-1").toString());
         assertTrue(rendition2Path.exists());
     }
 

--- a/src/test/java/com/adobe/skyline/migration/dao/ProcessingProfileDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/ProcessingProfileDAOTest.java
@@ -28,7 +28,7 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -48,14 +48,14 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
         super.setUp();
 
         File tempProjectRoot = projectLoader.copyConfProjectToTemp(temp);
-        this.projectRootPath = tempProjectRoot + "/" + TestConstants.CONF_WORKFLOW_PROJECT_NAME;
+        this.projectRootPath = Paths.get(tempProjectRoot.toString(), TestConstants.CONF_WORKFLOW_PROJECT_NAME).toString();
 
         this.dao = new ProcessingProfileDAO(projectRootPath);
     }
 
     @Test
     public void testProcessingRootPageCreated() throws ParserConfigurationException, SAXException, IOException {
-        File profileRootFile = new File(projectRootPath + "/" + MigrationConstants.PROCESSING_PROFILE_DISK_PATH + "/.content.xml");
+        File profileRootFile = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, ".content.xml").toString());
         assertFalse(profileRootFile.exists());
 
         ProcessingProfile profile = createTestProfile();
@@ -82,7 +82,7 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
 
     @Test
     public void testProfileAdded() throws ParserConfigurationException, SAXException, IOException {
-        File profilePath = new File(projectRootPath + "/" + MigrationConstants.PROCESSING_PROFILE_DISK_PATH + "/" + PROFILE_NAME);
+        File profilePath = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME).toString());
         assertFalse(profilePath.exists());
 
         ProcessingProfile profile = createTestProfile();
@@ -142,7 +142,7 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
 
     @Test
     public void testEmptyMimetypesIncluded() throws ParserConfigurationException, SAXException, IOException {
-        File profilePath = new File(projectRootPath + "/" + MigrationConstants.PROCESSING_PROFILE_DISK_PATH + "/" + PROFILE_NAME);
+        File profilePath = new File(Paths.get(projectRootPath,MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME).toString());
 
         RenditionConfig renditionConfig1 = createThumbnailRendition();
         ProcessingProfile profile = new ProcessingProfile();
@@ -178,9 +178,9 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
 
     @Test
     public void testDuplicateProfileNames() {
-        File profile1Path = new File(projectRootPath + "/" + MigrationConstants.PROCESSING_PROFILE_DISK_PATH + "/" + PROFILE_NAME);
-        File profile2Path = new File(projectRootPath + "/" + MigrationConstants.PROCESSING_PROFILE_DISK_PATH + "/" + PROFILE_NAME + "-1");
-        File profile3Path = new File(projectRootPath + "/" + MigrationConstants.PROCESSING_PROFILE_DISK_PATH + "/" + PROFILE_NAME + "-2");
+        File profile1Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME).toString());
+        File profile2Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME + "-1").toString());
+        File profile3Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME + "-2").toString());
 
         assertFalse(profile1Path.exists());
         assertFalse(profile2Path.exists());
@@ -212,9 +212,9 @@ public class ProcessingProfileDAOTest extends SkylineMigrationBaseTest {
 
         dao.addProfile(profile);
 
-        File rendition1Path = new File(projectRootPath + "/" + MigrationConstants.PROCESSING_PROFILE_DISK_PATH + "/" + PROFILE_NAME + "/thumbnail");
+        File rendition1Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME, "thumbnail").toString());
         assertTrue(rendition1Path.exists());
-        File rendition2Path = new File(projectRootPath + "/" + MigrationConstants.PROCESSING_PROFILE_DISK_PATH + "/" + PROFILE_NAME + "/thumbnail-1");
+        File rendition2Path = new File(Paths.get(projectRootPath, MigrationConstants.PROCESSING_PROFILE_DISK_PATH, PROFILE_NAME, "thumbnail-1").toString());
         assertTrue(rendition2Path.exists());
     }
 

--- a/src/test/java/com/adobe/skyline/migration/dao/WorkflowLauncherDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/WorkflowLauncherDAOTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.nio.file.Paths;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -69,8 +70,8 @@ public class WorkflowLauncherDAOTest extends SkylineMigrationBaseTest {
 
         launcher.setGlob(glob);
         launcher.setName(name);
-        launcher.setRelativePath(TestConstants.CONF_LAUNCHER_PATH + name + "/"
-                + MigrationConstants.CONTENT_XML);
+        launcher.setRelativePath(Paths.get(TestConstants.CONF_LAUNCHER_PATH, name,
+                MigrationConstants.CONTENT_XML).toString());
         launcher.setLauncherFile(new File(getAbsolutePathForConfLauncher(name)));
 
         return launcher;
@@ -91,7 +92,7 @@ public class WorkflowLauncherDAOTest extends SkylineMigrationBaseTest {
     }
 
     private String getAbsolutePathForConfLauncher(String launcherName) {
-        return tempProjectRoot.getPath() + File.separator + TestConstants.CONF_WORKFLOW_PROJECT_NAME + File.separator +
-                TestConstants.CONF_LAUNCHER_PATH + launcherName + File.separator + MigrationConstants.CONTENT_XML;
+        return Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
+                TestConstants.CONF_LAUNCHER_PATH, launcherName, MigrationConstants.CONTENT_XML).toString();
     }
 }

--- a/src/test/java/com/adobe/skyline/migration/dao/WorkflowLauncherDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/WorkflowLauncherDAOTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -70,7 +70,7 @@ public class WorkflowLauncherDAOTest extends SkylineMigrationBaseTest {
 
         launcher.setGlob(glob);
         launcher.setName(name);
-        launcher.setRelativePath(Paths.get(TestConstants.CONF_LAUNCHER_PATH, name,
+        launcher.setRelativePath(Path.of(TestConstants.CONF_LAUNCHER_PATH, name,
                 MigrationConstants.CONTENT_XML).toString());
         launcher.setLauncherFile(new File(getAbsolutePathForConfLauncher(name)));
 
@@ -92,7 +92,7 @@ public class WorkflowLauncherDAOTest extends SkylineMigrationBaseTest {
     }
 
     private String getAbsolutePathForConfLauncher(String launcherName) {
-        return Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
+        return Path.of(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
                 TestConstants.CONF_LAUNCHER_PATH, launcherName, MigrationConstants.CONTENT_XML).toString();
     }
 }

--- a/src/test/java/com/adobe/skyline/migration/dao/WorkflowModelDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/WorkflowModelDAOTest.java
@@ -13,6 +13,7 @@
 package com.adobe.skyline.migration.dao;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -82,8 +83,8 @@ public class WorkflowModelDAOTest extends SkylineMigrationBaseTest {
     public void testMissingVarNode() throws CustomerDataException {
         File projectRoot = projectLoader.copyNoModelProjectToTemp(temp);
 
-        WorkflowModel model = modelDAO.loadWorkflowModel(projectRoot + "/" +
-                TestConstants.CONF_WORKFLOW_PROJECT_NAME, "/conf/global/settings/workflow/models/dam/update_asset");
+        WorkflowModel model = modelDAO.loadWorkflowModel(Paths.get(projectRoot.getPath(),
+                TestConstants.CONF_WORKFLOW_PROJECT_NAME).toString(),  "/conf/global/settings/workflow/models/dam/update_asset");
 
         assertNotNull(model.getRuntimeComponent());
         assertNotNull(model.getConfigurationPage());
@@ -94,8 +95,8 @@ public class WorkflowModelDAOTest extends SkylineMigrationBaseTest {
     public void testModelStepCreatedWithMetadata() throws CustomerDataException {
         File projectRoot = projectLoader.copyConfProjectToTemp(temp);
 
-        WorkflowModel model = modelDAO.loadWorkflowModel(projectRoot + "/" +
-                TestConstants.CONF_WORKFLOW_PROJECT_NAME, PATH_TO_CONF_UPDATE_ASSET);
+        WorkflowModel model = modelDAO.loadWorkflowModel(Paths.get(projectRoot.getPath(),
+                TestConstants.CONF_WORKFLOW_PROJECT_NAME).toString(), PATH_TO_CONF_UPDATE_ASSET);
 
         boolean metadataFound = false;
 
@@ -154,7 +155,7 @@ public class WorkflowModelDAOTest extends SkylineMigrationBaseTest {
     @Test
     public void testStepAddedToNewConfFile() throws CustomerDataException {
         File projectRoot = projectLoader.copyConfProjectToTemp(temp);
-        String projectPath = projectRoot + "/" + TestConstants.CONF_WORKFLOW_PROJECT_NAME;
+        String projectPath = Paths.get(projectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME).toString();
 
         //Load model and ensure it doesn't contain the step
         WorkflowModel modelBefore = modelDAO.loadWorkflowModel(projectPath, PATH_TO_CONF_ASSET_NOCOMPLETE);
@@ -173,7 +174,7 @@ public class WorkflowModelDAOTest extends SkylineMigrationBaseTest {
     @Test
     public void testStepAddedToOldConfFile() throws CustomerDataException {
         File projectRoot = projectLoader.copyEtcProjectToTemp(temp);
-        String projectPath = projectRoot + "/" + TestConstants.ETC_WORKFLOW_PROJECT_NAME;
+        String projectPath = Paths.get(projectRoot.getPath(), TestConstants.ETC_WORKFLOW_PROJECT_NAME).toString();
 
         //Load model and ensure it doesn't contain the step
         WorkflowModel modelBefore = modelDAO.loadWorkflowModel(projectPath, PATH_TO_ETC_ASSET_NOCOMPLETE);

--- a/src/test/java/com/adobe/skyline/migration/dao/WorkflowRunnerConfigDAOTest.java
+++ b/src/test/java/com/adobe/skyline/migration/dao/WorkflowRunnerConfigDAOTest.java
@@ -26,14 +26,15 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 
 import static org.junit.Assert.*;
 
 public class WorkflowRunnerConfigDAOTest extends SkylineMigrationBaseTest {
 
-    private static final String CONFIG_FILE_REL_PATH = "/" + MigrationConstants.MIGRATION_PROJECT_APPS + MigrationConstants.PATH_TO_JCR_ROOT +
-            MigrationConstants.WORKFLOW_RUNNER_CONFIG_PATH + "/" + MigrationConstants.WORKFLOW_RUNNER_CONFIG_FILENAME;
+    private static final String CONFIG_FILE_REL_PATH = Paths.get("", MigrationConstants.MIGRATION_PROJECT_APPS, MigrationConstants.PATH_TO_JCR_ROOT,
+            MigrationConstants.WORKFLOW_RUNNER_CONFIG_PATH, MigrationConstants.WORKFLOW_RUNNER_CONFIG_FILENAME).toString();
 
     private static final String PATTERN = "\\/content\\/dam(\\/.*\\/)(marketing\\/seasonal)(\\/.*)";
     private static final String PATTERN_2 = "\\/content\\/dam(\\/.*\\/)(other_path)(\\/.*)";
@@ -52,12 +53,12 @@ public class WorkflowRunnerConfigDAOTest extends SkylineMigrationBaseTest {
 
         this.tempProjectRoot = projectLoader.copyConfProjectToTemp(temp);
 
-        this.dao = new WorkflowRunnerConfigDAO(tempProjectRoot + File.separator + MigrationConstants.MIGRATION_PROJECT_APPS);
+        this.dao = new WorkflowRunnerConfigDAO(Paths.get(tempProjectRoot.getPath(), MigrationConstants.MIGRATION_PROJECT_APPS).toString());
     }
 
     @Test
     public void testConfigFileCreated() throws IOException, ParserConfigurationException, SAXException {
-        File configFile = new File(tempProjectRoot + CONFIG_FILE_REL_PATH);
+        File configFile = new File(Paths.get(tempProjectRoot.getPath(), CONFIG_FILE_REL_PATH).toString());
         assertFalse(configFile.exists());
 
         dao.createConfigByExpression("", "");
@@ -75,7 +76,7 @@ public class WorkflowRunnerConfigDAOTest extends SkylineMigrationBaseTest {
         dao.createConfigByExpression(PATTERN, PATTERN_MODEL);
         dao.createConfigByExpression(PATTERN_2, PATTERN_MODEL);
 
-        File configFile = new File(tempProjectRoot + CONFIG_FILE_REL_PATH);
+        File configFile = new File(Paths.get(tempProjectRoot.getPath(), CONFIG_FILE_REL_PATH).toString());
         List<String> patternMappings = getPatternMappingsFromFile(configFile, MigrationConstants.WORKFLOW_RUNNER_CONFIG_BY_EXPRESSION);
 
         assertEquals(PATTERN + ":" + PATTERN_MODEL, patternMappings.get(0));
@@ -87,7 +88,7 @@ public class WorkflowRunnerConfigDAOTest extends SkylineMigrationBaseTest {
         dao.createConfigByPath(PATH, PATH_MODEL);
         dao.createConfigByPath(PATH_2, PATH_MODEL);
 
-        File configFile = new File(tempProjectRoot + CONFIG_FILE_REL_PATH);
+        File configFile = new File(Paths.get(tempProjectRoot.getPath(), CONFIG_FILE_REL_PATH).toString());
         List<String> patternMappings = getPatternMappingsFromFile(configFile, MigrationConstants.WORKFLOW_RUNNER_CONFIG_BY_PATH);
 
         assertEquals(PATH + ":" + PATH_MODEL, patternMappings.get(0));

--- a/src/test/java/com/adobe/skyline/migration/main/MigrationOrchestratorIntegrationTest.java
+++ b/src/test/java/com/adobe/skyline/migration/main/MigrationOrchestratorIntegrationTest.java
@@ -15,6 +15,7 @@ package com.adobe.skyline.migration.main;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
@@ -171,27 +172,27 @@ public class MigrationOrchestratorIntegrationTest extends SkylineMigrationBaseTe
     }
 
     private String getAbsolutePathForConfLauncher(File tempProjectRoot, String launcherName) {
-        String pathRoot = tempProjectRoot.getPath() + File.separator + TestConstants.CONF_WORKFLOW_PROJECT_NAME +
-                File.separator + TestConstants.CONF_LAUNCHER_PATH;
-        return pathRoot + launcherName + File.separator + MigrationConstants.CONTENT_XML;
+        String pathRoot = Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
+                TestConstants.CONF_LAUNCHER_PATH).toString();
+        return Paths.get(pathRoot, launcherName, MigrationConstants.CONTENT_XML).toString();
     }
 
     private String getAbsolutePathForEtcLauncher(File tempProjectRoot, String launcherName) {
-        String pathRoot = tempProjectRoot.getPath() + File.separator + TestConstants.ETC_WORKFLOW_PROJECT_NAME +
-                File.separator + TestConstants.ETC_LAUNCHER_PATH;
-        return pathRoot + launcherName + File.separator + MigrationConstants.CONTENT_XML;
+        String pathRoot = Paths.get(tempProjectRoot.getPath(), TestConstants.ETC_WORKFLOW_PROJECT_NAME,
+                TestConstants.ETC_LAUNCHER_PATH).toString();
+        return Paths.get(pathRoot, launcherName, MigrationConstants.CONTENT_XML).toString();
     }
 
     private String getAbsolutePathForConfModel(File tempProjectRoot, String workflowModelName) {
-        String pathRoot = tempProjectRoot.getPath() + File.separator + TestConstants.CONF_WORKFLOW_PROJECT_NAME +
-                File.separator + TestConstants.CONF_MODEL_PATH;
-        return pathRoot + workflowModelName + File.separator + MigrationConstants.CONTENT_XML;
+        String pathRoot = Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
+                TestConstants.CONF_MODEL_PATH).toString();
+        return Paths.get(pathRoot, workflowModelName, MigrationConstants.CONTENT_XML).toString();
     }
 
     private String getAbsolutePathForEtcModel(File tempProjectRoot, String workflowModelName) {
-        String pathRoot = tempProjectRoot.getPath() + File.separator + TestConstants.ETC_WORKFLOW_PROJECT_NAME +
-                File.separator + TestConstants.ETC_MODEL_PATH;
-        return pathRoot + workflowModelName + File.separator + MigrationConstants.CONTENT_XML;
+        String pathRoot = Paths.get(tempProjectRoot.getPath(), TestConstants.ETC_WORKFLOW_PROJECT_NAME,
+                TestConstants.ETC_MODEL_PATH).toString();
+        return Paths.get(pathRoot, workflowModelName, MigrationConstants.CONTENT_XML).toString();
     }
 
     private void assertStepsRemovedFromWorkflowModel(String[] workflowSteps, String workflowModelPath) {
@@ -289,14 +290,14 @@ public class MigrationOrchestratorIntegrationTest extends SkylineMigrationBaseTe
     }
 
     private File getRunnerConfig(File testProject) {
-        return new File(testProject.getPath() + File.separator + MigrationConstants.MIGRATION_PROJECT_APPS +
-                File.separator + MigrationConstants.PATH_TO_JCR_ROOT + MigrationConstants.WORKFLOW_RUNNER_CONFIG_PATH +
-                File.separator + MigrationConstants.WORKFLOW_RUNNER_CONFIG_FILENAME);
+        return new File(Paths.get(testProject.getPath(), MigrationConstants.MIGRATION_PROJECT_APPS,
+                MigrationConstants.PATH_TO_JCR_ROOT, MigrationConstants.WORKFLOW_RUNNER_CONFIG_PATH,
+                MigrationConstants.WORKFLOW_RUNNER_CONFIG_FILENAME).toString());
     }
 
     private void assertProcessingProfilesCreated(File testProject, List<String> profileNames) {
-        File profileRoot = new File(testProject.getPath() + File.separator + MigrationConstants.MIGRATION_PROJECT_CONTENT +
-                File.separator + MigrationConstants.PROCESSING_PROFILE_DISK_PATH);
+        File profileRoot = new File(Paths.get(testProject.getPath(), MigrationConstants.MIGRATION_PROJECT_CONTENT,
+                MigrationConstants.PROCESSING_PROFILE_DISK_PATH).toString());
         File[] children = profileRoot.listFiles();
 
         for (String profileName:profileNames) {
@@ -315,8 +316,8 @@ public class MigrationOrchestratorIntegrationTest extends SkylineMigrationBaseTe
     }
 
     private void assertNoProcessingProfilesCreated(File testProject) {
-        File profileRoot = new File(testProject.getPath() + File.separator + MigrationConstants.MIGRATION_PROJECT_CONTENT +
-                File.separator + MigrationConstants.PROCESSING_PROFILE_DISK_PATH);
+        File profileRoot = new File(Paths.get(testProject.getPath(), MigrationConstants.MIGRATION_PROJECT_CONTENT,
+                MigrationConstants.PROCESSING_PROFILE_DISK_PATH).toString());
         assertFalse(profileRoot.exists());
     }
 

--- a/src/test/java/com/adobe/skyline/migration/main/MigrationOrchestratorIntegrationTest.java
+++ b/src/test/java/com/adobe/skyline/migration/main/MigrationOrchestratorIntegrationTest.java
@@ -15,7 +15,7 @@ package com.adobe.skyline.migration.main;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
@@ -172,27 +172,27 @@ public class MigrationOrchestratorIntegrationTest extends SkylineMigrationBaseTe
     }
 
     private String getAbsolutePathForConfLauncher(File tempProjectRoot, String launcherName) {
-        String pathRoot = Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
+        String pathRoot = Path.of(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
                 TestConstants.CONF_LAUNCHER_PATH).toString();
-        return Paths.get(pathRoot, launcherName, MigrationConstants.CONTENT_XML).toString();
+        return Path.of(pathRoot, launcherName, MigrationConstants.CONTENT_XML).toString();
     }
 
     private String getAbsolutePathForEtcLauncher(File tempProjectRoot, String launcherName) {
-        String pathRoot = Paths.get(tempProjectRoot.getPath(), TestConstants.ETC_WORKFLOW_PROJECT_NAME,
+        String pathRoot = Path.of(tempProjectRoot.getPath(), TestConstants.ETC_WORKFLOW_PROJECT_NAME,
                 TestConstants.ETC_LAUNCHER_PATH).toString();
-        return Paths.get(pathRoot, launcherName, MigrationConstants.CONTENT_XML).toString();
+        return Path.of(pathRoot, launcherName, MigrationConstants.CONTENT_XML).toString();
     }
 
     private String getAbsolutePathForConfModel(File tempProjectRoot, String workflowModelName) {
-        String pathRoot = Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
+        String pathRoot = Path.of(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
                 TestConstants.CONF_MODEL_PATH).toString();
-        return Paths.get(pathRoot, workflowModelName, MigrationConstants.CONTENT_XML).toString();
+        return Path.of(pathRoot, workflowModelName, MigrationConstants.CONTENT_XML).toString();
     }
 
     private String getAbsolutePathForEtcModel(File tempProjectRoot, String workflowModelName) {
-        String pathRoot = Paths.get(tempProjectRoot.getPath(), TestConstants.ETC_WORKFLOW_PROJECT_NAME,
+        String pathRoot = Path.of(tempProjectRoot.getPath(), TestConstants.ETC_WORKFLOW_PROJECT_NAME,
                 TestConstants.ETC_MODEL_PATH).toString();
-        return Paths.get(pathRoot, workflowModelName, MigrationConstants.CONTENT_XML).toString();
+        return Path.of(pathRoot, workflowModelName, MigrationConstants.CONTENT_XML).toString();
     }
 
     private void assertStepsRemovedFromWorkflowModel(String[] workflowSteps, String workflowModelPath) {
@@ -290,13 +290,13 @@ public class MigrationOrchestratorIntegrationTest extends SkylineMigrationBaseTe
     }
 
     private File getRunnerConfig(File testProject) {
-        return new File(Paths.get(testProject.getPath(), MigrationConstants.MIGRATION_PROJECT_APPS,
+        return new File(Path.of(testProject.getPath(), MigrationConstants.MIGRATION_PROJECT_APPS,
                 MigrationConstants.PATH_TO_JCR_ROOT, MigrationConstants.WORKFLOW_RUNNER_CONFIG_PATH,
                 MigrationConstants.WORKFLOW_RUNNER_CONFIG_FILENAME).toString());
     }
 
     private void assertProcessingProfilesCreated(File testProject, List<String> profileNames) {
-        File profileRoot = new File(Paths.get(testProject.getPath(), MigrationConstants.MIGRATION_PROJECT_CONTENT,
+        File profileRoot = new File(Path.of(testProject.getPath(), MigrationConstants.MIGRATION_PROJECT_CONTENT,
                 MigrationConstants.PROCESSING_PROFILE_DISK_PATH).toString());
         File[] children = profileRoot.listFiles();
 
@@ -316,7 +316,7 @@ public class MigrationOrchestratorIntegrationTest extends SkylineMigrationBaseTe
     }
 
     private void assertNoProcessingProfilesCreated(File testProject) {
-        File profileRoot = new File(Paths.get(testProject.getPath(), MigrationConstants.MIGRATION_PROJECT_CONTENT,
+        File profileRoot = new File(Path.of(testProject.getPath(), MigrationConstants.MIGRATION_PROJECT_CONTENT,
                 MigrationConstants.PROCESSING_PROFILE_DISK_PATH).toString());
         assertFalse(profileRoot.exists());
     }

--- a/src/test/java/com/adobe/skyline/migration/parser/CustomerProjectLoaderTest.java
+++ b/src/test/java/com/adobe/skyline/migration/parser/CustomerProjectLoaderTest.java
@@ -29,7 +29,7 @@ import com.adobe.skyline.migration.exception.CustomerDataException;
 import com.adobe.skyline.migration.testutils.TestConstants;
 
 import java.io.File;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 
 public class CustomerProjectLoaderTest extends SkylineMigrationBaseTest {
@@ -179,7 +179,7 @@ public class CustomerProjectLoaderTest extends SkylineMigrationBaseTest {
     public void testAllProjectLocated() throws CustomerDataException {
         String reactorPath = projectLoader.copyMigratedProjectToTemp(temp).getPath();
         String allPath = loader.getContainerProjectPath(reactorPath);
-        assertEquals(Paths.get(reactorPath, TestConstants.CONTAINER_PACKAGE_PROJECT_NAME).toString(), allPath);
+        assertEquals(Path.of(reactorPath, TestConstants.CONTAINER_PACKAGE_PROJECT_NAME).toString(), allPath);
     }
     
     private void validateLauncherPaths(List<WorkflowProject> projects, String launcherRoot) {

--- a/src/test/java/com/adobe/skyline/migration/parser/CustomerProjectLoaderTest.java
+++ b/src/test/java/com/adobe/skyline/migration/parser/CustomerProjectLoaderTest.java
@@ -28,6 +28,7 @@ import com.adobe.skyline.migration.SkylineMigrationBaseTest;
 import com.adobe.skyline.migration.exception.CustomerDataException;
 import com.adobe.skyline.migration.testutils.TestConstants;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -191,8 +192,8 @@ public class CustomerProjectLoaderTest extends SkylineMigrationBaseTest {
                     assertTrue(relPath.contains(MigrationConstants.CONFIG));
                     assertTrue(relPath.contains(MigrationConstants.CONTENT_XML));
 
-                    String launcherFolder = relPath.substring(0, relPath.lastIndexOf("\\"));
-                    String launcherConfigRoot = launcherFolder.substring(0, launcherFolder.lastIndexOf("\\"));
+                    String launcherFolder = relPath.substring(0, relPath.lastIndexOf(File.separator));
+                    String launcherConfigRoot = launcherFolder.substring(0, launcherFolder.lastIndexOf(File.separator));
                     assertEquals(launcherRoot, launcherConfigRoot);
                 }
             }

--- a/src/test/java/com/adobe/skyline/migration/parser/CustomerProjectLoaderTest.java
+++ b/src/test/java/com/adobe/skyline/migration/parser/CustomerProjectLoaderTest.java
@@ -28,6 +28,7 @@ import com.adobe.skyline.migration.SkylineMigrationBaseTest;
 import com.adobe.skyline.migration.exception.CustomerDataException;
 import com.adobe.skyline.migration.testutils.TestConstants;
 
+import java.nio.file.Paths;
 import java.util.List;
 
 public class CustomerProjectLoaderTest extends SkylineMigrationBaseTest {
@@ -177,7 +178,7 @@ public class CustomerProjectLoaderTest extends SkylineMigrationBaseTest {
     public void testAllProjectLocated() throws CustomerDataException {
         String reactorPath = projectLoader.copyMigratedProjectToTemp(temp).getPath();
         String allPath = loader.getContainerProjectPath(reactorPath);
-        assertEquals(reactorPath + "/" + TestConstants.CONTAINER_PACKAGE_PROJECT_NAME, allPath);
+        assertEquals(Paths.get(reactorPath, TestConstants.CONTAINER_PACKAGE_PROJECT_NAME).toString(), allPath);
     }
     
     private void validateLauncherPaths(List<WorkflowProject> projects, String launcherRoot) {
@@ -190,8 +191,8 @@ public class CustomerProjectLoaderTest extends SkylineMigrationBaseTest {
                     assertTrue(relPath.contains(MigrationConstants.CONFIG));
                     assertTrue(relPath.contains(MigrationConstants.CONTENT_XML));
 
-                    String launcherFolder = relPath.substring(0, relPath.lastIndexOf("/"));
-                    String launcherConfigRoot = launcherFolder.substring(0, launcherFolder.lastIndexOf("/"));
+                    String launcherFolder = relPath.substring(0, relPath.lastIndexOf("\\"));
+                    String launcherConfigRoot = launcherFolder.substring(0, launcherFolder.lastIndexOf("\\"));
                     assertEquals(launcherRoot, launcherConfigRoot);
                 }
             }

--- a/src/test/java/com/adobe/skyline/migration/testutils/TestConstants.java
+++ b/src/test/java/com/adobe/skyline/migration/testutils/TestConstants.java
@@ -11,23 +11,25 @@
  */
 
 package com.adobe.skyline.migration.testutils;
+import java.nio.file.Paths;
 
-public class TestConstants {
+public final class TestConstants {
     public static final String TEST_PROJECT_GROUP_ID = "com.adobe.sample";
     public static final String TEST_PROJECT_ARTIFACT_ID = "sample";
     public static final String TEST_PROJECT_VERSION = "1.0-SNAPSHOT";
 
     public static final String CONF_WORKFLOW_PROJECT_NAME = "ui.content";
-    public static final String CONF_WORKFLOW_PATH = "/src/main/content/jcr_root/conf/global/settings/workflow";
-    public static final String CONF_LAUNCHER_PATH = CONF_WORKFLOW_PATH + "/launcher/config/";
-    public static final String CONF_MODEL_PATH =  CONF_WORKFLOW_PATH + "/models/";
+    public static final String MAIN_CONTENT_PATH = Paths.get("src", "main", "content").toString();
+    public static final String CONF_WORKFLOW_PATH = Paths.get(MAIN_CONTENT_PATH, "jcr_root", "conf", "global", "settings", "workflow").toString();
+    public static final String CONF_LAUNCHER_PATH = Paths.get(CONF_WORKFLOW_PATH, "launcher", "config").toString();
+    public static final String CONF_MODEL_PATH =  Paths.get(CONF_WORKFLOW_PATH, "models").toString();
 
     public static final String ETC_WORKFLOW_PROJECT_NAME = "ui.apps";
-    public static final String ETC_WORKFLOW_PATH = "/src/main/content/jcr_root/etc/workflow";
-    public static final String ETC_LAUNCHER_PATH = ETC_WORKFLOW_PATH + "/launcher/config/";
-    public static final String ETC_MODEL_PATH =  ETC_WORKFLOW_PATH + "/models/";
+    public static final String ETC_WORKFLOW_PATH = Paths.get(MAIN_CONTENT_PATH, "jcr_root", "etc", "workflow").toString();
+    public static final String ETC_LAUNCHER_PATH = Paths.get(ETC_WORKFLOW_PATH, "launcher", "config").toString();
+    public static final String ETC_MODEL_PATH =  Paths.get(ETC_WORKFLOW_PATH, "models").toString();
 
-    public static final String VAR_WORKFLOW_PATH = "/src/main/content/jcr_root/var/workflow";
+    public static final String VAR_WORKFLOW_PATH = Paths.get(MAIN_CONTENT_PATH, "jcr_root", "var", "workflow").toString();
 
     public static final String CONTAINER_PACKAGE_PROJECT_NAME = "all";
 }

--- a/src/test/java/com/adobe/skyline/migration/testutils/TestConstants.java
+++ b/src/test/java/com/adobe/skyline/migration/testutils/TestConstants.java
@@ -11,7 +11,7 @@
  */
 
 package com.adobe.skyline.migration.testutils;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 public final class TestConstants {
     public static final String TEST_PROJECT_GROUP_ID = "com.adobe.sample";
@@ -19,17 +19,17 @@ public final class TestConstants {
     public static final String TEST_PROJECT_VERSION = "1.0-SNAPSHOT";
 
     public static final String CONF_WORKFLOW_PROJECT_NAME = "ui.content";
-    public static final String MAIN_CONTENT_PATH = Paths.get("src", "main", "content").toString();
-    public static final String CONF_WORKFLOW_PATH = Paths.get(MAIN_CONTENT_PATH, "jcr_root", "conf", "global", "settings", "workflow").toString();
-    public static final String CONF_LAUNCHER_PATH = Paths.get(CONF_WORKFLOW_PATH, "launcher", "config").toString();
-    public static final String CONF_MODEL_PATH =  Paths.get(CONF_WORKFLOW_PATH, "models").toString();
+    public static final String MAIN_CONTENT_PATH = Path.of("src", "main", "content").toString();
+    public static final String CONF_WORKFLOW_PATH = Path.of(MAIN_CONTENT_PATH, "jcr_root", "conf", "global", "settings", "workflow").toString();
+    public static final String CONF_LAUNCHER_PATH = Path.of(CONF_WORKFLOW_PATH, "launcher", "config").toString();
+    public static final String CONF_MODEL_PATH =  Path.of(CONF_WORKFLOW_PATH, "models").toString();
 
     public static final String ETC_WORKFLOW_PROJECT_NAME = "ui.apps";
-    public static final String ETC_WORKFLOW_PATH = Paths.get(MAIN_CONTENT_PATH, "jcr_root", "etc", "workflow").toString();
-    public static final String ETC_LAUNCHER_PATH = Paths.get(ETC_WORKFLOW_PATH, "launcher", "config").toString();
-    public static final String ETC_MODEL_PATH =  Paths.get(ETC_WORKFLOW_PATH, "models").toString();
+    public static final String ETC_WORKFLOW_PATH = Path.of(MAIN_CONTENT_PATH, "jcr_root", "etc", "workflow").toString();
+    public static final String ETC_LAUNCHER_PATH = Path.of(ETC_WORKFLOW_PATH, "launcher", "config").toString();
+    public static final String ETC_MODEL_PATH =  Path.of(ETC_WORKFLOW_PATH, "models").toString();
 
-    public static final String VAR_WORKFLOW_PATH = Paths.get(MAIN_CONTENT_PATH, "jcr_root", "var", "workflow").toString();
+    public static final String VAR_WORKFLOW_PATH = Path.of(MAIN_CONTENT_PATH, "jcr_root", "var", "workflow").toString();
 
     public static final String CONTAINER_PACKAGE_PROJECT_NAME = "all";
 }

--- a/src/test/java/com/adobe/skyline/migration/transformer/LauncherDisablerTest.java
+++ b/src/test/java/com/adobe/skyline/migration/transformer/LauncherDisablerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.io.File;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -131,7 +131,7 @@ public class LauncherDisablerTest extends SkylineMigrationBaseTest {
     }
 
     private String getAbsolutePathForLauncher(String launcherName) {
-        return Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
+        return Path.of(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
                 TestConstants.CONF_LAUNCHER_PATH, launcherName, MigrationConstants.CONTENT_XML).toString();
     }
 }

--- a/src/test/java/com/adobe/skyline/migration/transformer/LauncherDisablerTest.java
+++ b/src/test/java/com/adobe/skyline/migration/transformer/LauncherDisablerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -130,7 +131,7 @@ public class LauncherDisablerTest extends SkylineMigrationBaseTest {
     }
 
     private String getAbsolutePathForLauncher(String launcherName) {
-        return tempProjectRoot.getPath() + File.separator + TestConstants.CONF_WORKFLOW_PROJECT_NAME + File.separator +
-                TestConstants.CONF_LAUNCHER_PATH + launcherName + File.separator + MigrationConstants.CONTENT_XML;
+        return Paths.get(tempProjectRoot.getPath(), TestConstants.CONF_WORKFLOW_PROJECT_NAME,
+                TestConstants.CONF_LAUNCHER_PATH, launcherName, MigrationConstants.CONTENT_XML).toString();
     }
 }

--- a/src/test/java/com/adobe/skyline/migration/transformer/VarNodeCleanerTest.java
+++ b/src/test/java/com/adobe/skyline/migration/transformer/VarNodeCleanerTest.java
@@ -25,6 +25,8 @@ import com.adobe.skyline.migration.dao.FilterFileDAO;
 import com.adobe.skyline.migration.model.ChangeTrackingService;
 import com.adobe.skyline.migration.model.workflow.WorkflowProject;
 
+import static com.adobe.skyline.migration.MigrationConstants.*;
+import static com.adobe.skyline.migration.testutils.TestConstants.CONF_WORKFLOW_PROJECT_NAME;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
@@ -73,6 +75,6 @@ public class VarNodeCleanerTest extends SkylineMigrationBaseTest {
 
         assertFalse(varWorkflowDir.exists());
         verify(filterFileDAO).removePath("/var/workflow");
-        verify(changeTrackingService).trackVarPathDeleted(endsWith("ui.content/src/main/content/jcr_root/var/workflow"));
+        verify(changeTrackingService).trackVarPathDeleted(endsWith(CONF_WORKFLOW_PROJECT_NAME + File.separator + SRC + File.separator + MAIN + File.separator + CONTENT + File.separator + JCR_ROOT_ON_DISK + File.separator + VAR + File.separator + WORKFLOW));
     }
 }

--- a/src/test/java/com/adobe/skyline/migration/transformer/processingprofile/ProcessingProfileCreatorTest.java
+++ b/src/test/java/com/adobe/skyline/migration/transformer/processingprofile/ProcessingProfileCreatorTest.java
@@ -89,7 +89,7 @@ public class ProcessingProfileCreatorTest extends SkylineMigrationBaseTest {
 
         List<ProcessingProfile> createdProfiles = changeTracker.getProcessingProfilesCreated();
         assertEquals(1, createdProfiles.size());
-        assertEquals("Migrated from " + WORKFLOW_NAME ,createdProfiles.get(0).getName());
+        assertEquals("Migrated from " + WORKFLOW_NAME, createdProfiles.get(0).getName());
     }
 
     @Test

--- a/src/test/java/com/adobe/skyline/migration/util/file/FileQueryServiceTest.java
+++ b/src/test/java/com/adobe/skyline/migration/util/file/FileQueryServiceTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Test;
@@ -25,8 +26,8 @@ import com.adobe.skyline.migration.testutils.TestConstants;
 
 public class FileQueryServiceTest extends SkylineMigrationBaseTest {
 
-    private static final String PATH_TO_CONF_WORKFLOW = "/" + TestConstants.CONF_WORKFLOW_PROJECT_NAME + TestConstants.CONF_WORKFLOW_PATH;
-    private static final String PATH_TO_VAR_WORKFLOW = "/" + TestConstants.CONF_WORKFLOW_PROJECT_NAME + TestConstants.VAR_WORKFLOW_PATH;
+    private static final String PATH_TO_CONF_WORKFLOW = Paths.get(TestConstants.CONF_WORKFLOW_PROJECT_NAME, TestConstants.CONF_WORKFLOW_PATH).toString();
+    private static final String PATH_TO_VAR_WORKFLOW = Paths.get(TestConstants.CONF_WORKFLOW_PROJECT_NAME, TestConstants.VAR_WORKFLOW_PATH).toString();
 
 
     @Test
@@ -41,9 +42,9 @@ public class FileQueryServiceTest extends SkylineMigrationBaseTest {
         boolean varFound = false;
 
         for (String path : result) {
-            if(path.equals(projectPath + PATH_TO_CONF_WORKFLOW)) {
+            if(path.equals(Paths.get(projectPath, PATH_TO_CONF_WORKFLOW).toString())) {
                 confFound = true;
-            } else if (path.equals(projectPath + PATH_TO_VAR_WORKFLOW)) {
+            } else if (path.equals(Paths.get(projectPath, PATH_TO_VAR_WORKFLOW).toString())) {
                 varFound = true;
             }
         }
@@ -56,7 +57,7 @@ public class FileQueryServiceTest extends SkylineMigrationBaseTest {
         String projectPath = projectLoader.copyConfProjectToTemp(temp).getPath();
         String subDirectoryName = "workflow";
 
-        List<String> result = queryService.findFileByName(subDirectoryName, new File(projectPath + PATH_TO_CONF_WORKFLOW));
+        List<String> result = queryService.findFileByName(subDirectoryName, new File(Paths.get(projectPath, PATH_TO_CONF_WORKFLOW).toString()));
         assertEquals("File not found.", 1, result.size());
     }
 

--- a/src/test/java/com/adobe/skyline/migration/util/file/FileQueryServiceTest.java
+++ b/src/test/java/com/adobe/skyline/migration/util/file/FileQueryServiceTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.Test;
@@ -26,8 +26,8 @@ import com.adobe.skyline.migration.testutils.TestConstants;
 
 public class FileQueryServiceTest extends SkylineMigrationBaseTest {
 
-    private static final String PATH_TO_CONF_WORKFLOW = Paths.get(TestConstants.CONF_WORKFLOW_PROJECT_NAME, TestConstants.CONF_WORKFLOW_PATH).toString();
-    private static final String PATH_TO_VAR_WORKFLOW = Paths.get(TestConstants.CONF_WORKFLOW_PROJECT_NAME, TestConstants.VAR_WORKFLOW_PATH).toString();
+    private static final String PATH_TO_CONF_WORKFLOW = Path.of(TestConstants.CONF_WORKFLOW_PROJECT_NAME, TestConstants.CONF_WORKFLOW_PATH).toString();
+    private static final String PATH_TO_VAR_WORKFLOW = Path.of(TestConstants.CONF_WORKFLOW_PROJECT_NAME, TestConstants.VAR_WORKFLOW_PATH).toString();
 
 
     @Test
@@ -42,9 +42,9 @@ public class FileQueryServiceTest extends SkylineMigrationBaseTest {
         boolean varFound = false;
 
         for (String path : result) {
-            if(path.equals(Paths.get(projectPath, PATH_TO_CONF_WORKFLOW).toString())) {
+            if(path.equals(Path.of(projectPath, PATH_TO_CONF_WORKFLOW).toString())) {
                 confFound = true;
-            } else if (path.equals(Paths.get(projectPath, PATH_TO_VAR_WORKFLOW).toString())) {
+            } else if (path.equals(Path.of(projectPath, PATH_TO_VAR_WORKFLOW).toString())) {
                 varFound = true;
             }
         }
@@ -57,7 +57,7 @@ public class FileQueryServiceTest extends SkylineMigrationBaseTest {
         String projectPath = projectLoader.copyConfProjectToTemp(temp).getPath();
         String subDirectoryName = "workflow";
 
-        List<String> result = queryService.findFileByName(subDirectoryName, new File(Paths.get(projectPath, PATH_TO_CONF_WORKFLOW).toString()));
+        List<String> result = queryService.findFileByName(subDirectoryName, new File(Path.of(projectPath, PATH_TO_CONF_WORKFLOW).toString()));
         assertEquals("File not found.", 1, result.size());
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- The changes will fix the use cases where the tool fails for windows machine 
- Also the failing test cases are fixed
- The Path.of takes care of platform independence wherever possible
- We have to diifferentiate between the file system paths and jcr paths.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.